### PR TITLE
Конвертация camelCase модификторов в dashed-style

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,12 +48,13 @@ module.exports = function bem(componentName) {
             mods
                 ? Object.keys(mods).reduce(function (result, name) {
                     var value = mods[name];
+                    var dashedName = name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
 
                     if (value) {
                         result += ' ' + (
                             typeof value === 'boolean'
-                                ? (base + '_' + name)
-                                : (base + '_' + name + '_' + value)
+                                ? (base + '_' + dashedName)
+                                : (base + '_' + dashedName + '_' + value)
                         );
                     }
 

--- a/test.js
+++ b/test.js
@@ -50,4 +50,14 @@ describe('bem-cn', function () {
             'block-name__element-name block-name__element-name_some-mod_visible block-name__element-name_some-mod2'
         );
     });
+
+    it('sould convert camelCase to dashed-style', () => {
+        var b = bem('block-name');
+        expect(b({
+            someMod: 'visible',
+            someMod2: true
+        })).to.be.equal(
+            'block-name block-name_some-mod_visible block-name_some-mod2'
+        )
+    })
 });


### PR DESCRIPTION
Как насчет вот такой конвертации?

Используем cn-decorator – у многих было ожидание, что camelCase модификаторы будут переведены в dashed-style